### PR TITLE
feat: startup update notice popup and publish pck safeguards

### DIFF
--- a/Config/MoreCustomsConfig.cs
+++ b/Config/MoreCustomsConfig.cs
@@ -44,9 +44,10 @@ public static class MoreCustomsConfig
       bool hasEndlessDoubleBossExtraHpPercent = raw.Contains("\"EndlessDoubleBossExtraHpPercent\"", StringComparison.OrdinalIgnoreCase);
       bool hasEndlessEnemyStrengthEveryActs = raw.Contains("\"EndlessEnemyStrengthEveryActs\"", StringComparison.OrdinalIgnoreCase);
       bool hasEndlessEnemyStrengthPerStep = raw.Contains("\"EndlessEnemyStrengthPerStep\"", StringComparison.OrdinalIgnoreCase);
+      bool hasLastSeenUpdateNoticeVersion = raw.Contains("\"LastSeenUpdateNoticeVersion\"", StringComparison.OrdinalIgnoreCase);
 
       bool normalizedChanged = Normalize();
-      bool shouldRewrite = loaded == null || !hasBossHpMultiplier || !hasPlatingBasePerAct || !hasGoldGainMultiplier || !hasRestSiteSmithCount || !hasEnableEndlessDebugLogs || !hasEndlessEnemyHpPerActPercent || !hasEndlessBossExtraHpPerActPercent || !hasEndlessDoubleBossExtraHpPercent || !hasEndlessEnemyStrengthEveryActs || !hasEndlessEnemyStrengthPerStep || normalizedChanged;
+      bool shouldRewrite = loaded == null || !hasBossHpMultiplier || !hasPlatingBasePerAct || !hasGoldGainMultiplier || !hasRestSiteSmithCount || !hasEnableEndlessDebugLogs || !hasEndlessEnemyHpPerActPercent || !hasEndlessBossExtraHpPerActPercent || !hasEndlessDoubleBossExtraHpPercent || !hasEndlessEnemyStrengthEveryActs || !hasEndlessEnemyStrengthPerStep || !hasLastSeenUpdateNoticeVersion || normalizedChanged;
 
       if (shouldRewrite)
       {
@@ -126,7 +127,34 @@ public static class MoreCustomsConfig
       changed = true;
     }
 
+    if (Current.LastSeenUpdateNoticeVersion == null)
+    {
+      Current.LastSeenUpdateNoticeVersion = string.Empty;
+      changed = true;
+    }
+
     return changed;
+  }
+
+  public static bool ShouldShowUpdateNotice(string currentVersion)
+  {
+    if (string.IsNullOrWhiteSpace(currentVersion) || string.Equals(currentVersion, "unknown", StringComparison.OrdinalIgnoreCase))
+    {
+      return false;
+    }
+
+    return !string.Equals(Current.LastSeenUpdateNoticeVersion, currentVersion, StringComparison.OrdinalIgnoreCase);
+  }
+
+  public static void MarkUpdateNoticeSeen(string currentVersion)
+  {
+    if (string.IsNullOrWhiteSpace(currentVersion))
+    {
+      return;
+    }
+
+    Current.LastSeenUpdateNoticeVersion = currentVersion;
+    SaveCurrent();
   }
 
   private static void SaveCurrent()
@@ -159,5 +187,7 @@ public static class MoreCustomsConfig
     public int EndlessEnemyStrengthEveryActs { get; set; } = 1;
 
     public int EndlessEnemyStrengthPerStep { get; set; } = 1;
+
+    public string LastSeenUpdateNoticeVersion { get; set; } = string.Empty;
   }
 }

--- a/MainFile.cs
+++ b/MainFile.cs
@@ -1,10 +1,15 @@
 using System;
 using System.IO;
 using System.Linq;
+using System.Reflection;
+using System.Text.Json;
 using Godot;
 using HarmonyLib;
+using MegaCrit.Sts2.Core.Nodes;
+using MegaCrit.Sts2.Core.Nodes.Screens.MainMenu;
 using MegaCrit.Sts2.Core.Modding;
 using ModTemplate.Config;
+using ModTemplate.Patches;
 
 namespace ModTemplate;
 
@@ -12,19 +17,23 @@ namespace ModTemplate;
 public partial class MainFile : Node
 {
 	private const string ModId = "MoreCustoms"; //At the moment, this is used only for the Logger and harmony names.
+	private const string UnknownVersion = "unknown";
 
 	public static MegaCrit.Sts2.Core.Logging.Logger Logger { get; } = new(ModId, MegaCrit.Sts2.Core.Logging.LogType.Generic);
+	public static string ModVersion { get; private set; } = UnknownVersion;
 
 	public static void Initialize()
 	{
 		Logger.Info("[MoreCustoms] Initialize begin.");
 		LogBaseLibStatus();
 		MoreCustomsConfig.LoadOrCreate(Logger);
+		LoadModVersion();
 
 		Harmony harmony = new(ModId);
 
 		harmony.PatchAll();
 		Logger.Info("[MoreCustoms] Harmony PatchAll complete.");
+		EnsureUpdateNoticePatchInstalled(harmony);
 	}
 
 	private static void LogBaseLibStatus()
@@ -72,6 +81,86 @@ public partial class MainFile : Node
 		catch (Exception ex)
 		{
 			Logger.Error($"[MoreCustoms] Failed to log BaseLib status: {ex}");
+		}
+	}
+
+	private static void LoadModVersion()
+	{
+		try
+		{
+			string gameDir = Path.GetDirectoryName(OS.GetExecutablePath()) ?? ".";
+			string manifestPath = Path.Combine(gameDir, "mods", ModId, $"{ModId}.json");
+			if (!File.Exists(manifestPath))
+			{
+				Logger.Warn($"[MoreCustoms] Manifest not found at {manifestPath}, using fallback version '{UnknownVersion}'.");
+				ModVersion = UnknownVersion;
+				return;
+			}
+
+			using JsonDocument document = JsonDocument.Parse(File.ReadAllText(manifestPath));
+			if (document.RootElement.TryGetProperty("version", out JsonElement versionElement))
+			{
+				string? version = versionElement.GetString();
+				ModVersion = string.IsNullOrWhiteSpace(version) ? UnknownVersion : version;
+			}
+			else
+			{
+				ModVersion = UnknownVersion;
+			}
+
+			Logger.Info($"[MoreCustoms] Loaded mod version: {ModVersion}");
+		}
+		catch (Exception ex)
+		{
+			ModVersion = UnknownVersion;
+			Logger.Error($"[MoreCustoms] Failed to load mod version: {ex.Message}");
+		}
+	}
+
+	private static void EnsureUpdateNoticePatchInstalled(Harmony harmony)
+	{
+		try
+		{
+			MethodInfo? runReadyMethod = AccessTools.Method(typeof(NRun), nameof(NRun._Ready));
+			MethodInfo? gameReadyMethod = AccessTools.Method(typeof(NGame), nameof(NGame._Ready));
+			MethodInfo? mainMenuReadyMethod = AccessTools.Method(typeof(NMainMenu), nameof(NMainMenu._Ready));
+
+			MethodInfo? runPatchMethod = AccessTools.Method(typeof(UpdateNoticePopupPatch), "ShowUpdateNoticeAfterRunReady");
+
+			if (runReadyMethod == null || runPatchMethod == null)
+			{
+				Logger.Warn($"[UpdateNotice] Patch verification skipped. runReadyMethodNull={runReadyMethod == null}, runPatchMethodNull={runPatchMethod == null}");
+				return;
+			}
+
+			var runPatchInfo = Harmony.GetPatchInfo(runReadyMethod);
+			bool runPatchedByThisMod = runPatchInfo?.Postfixes.Any(p => string.Equals(p.owner, ModId, StringComparison.OrdinalIgnoreCase)) == true;
+
+			Logger.Info($"[UpdateNotice] Patch check for NRun._Ready: alreadyPatchedByThisMod={runPatchedByThisMod}, postfixCount={runPatchInfo?.Postfixes.Count ?? 0}");
+
+			if (gameReadyMethod != null)
+			{
+				var gamePatchInfo = Harmony.GetPatchInfo(gameReadyMethod);
+				bool gamePatchedByThisMod = gamePatchInfo?.Postfixes.Any(p => string.Equals(p.owner, ModId, StringComparison.OrdinalIgnoreCase)) == true;
+				Logger.Info($"[UpdateNotice] Patch check for NGame._Ready: alreadyPatchedByThisMod={gamePatchedByThisMod}, postfixCount={gamePatchInfo?.Postfixes.Count ?? 0}");
+			}
+
+			if (mainMenuReadyMethod != null)
+			{
+				var menuPatchInfo = Harmony.GetPatchInfo(mainMenuReadyMethod);
+				bool menuPatchedByThisMod = menuPatchInfo?.Postfixes.Any(p => string.Equals(p.owner, ModId, StringComparison.OrdinalIgnoreCase)) == true;
+				Logger.Info($"[UpdateNotice] Patch check for NMainMenu._Ready: alreadyPatchedByThisMod={menuPatchedByThisMod}, postfixCount={menuPatchInfo?.Postfixes.Count ?? 0}");
+			}
+
+			if (!runPatchedByThisMod)
+			{
+				harmony.Patch(runReadyMethod, postfix: new HarmonyMethod(runPatchMethod));
+				Logger.Warn("[UpdateNotice] Applied manual fallback patch to NRun._Ready.");
+			}
+		}
+		catch (Exception ex)
+		{
+			Logger.Error($"[UpdateNotice] Patch verification failed: {ex}");
 		}
 	}
 

--- a/MoreCustoms.csproj
+++ b/MoreCustoms.csproj
@@ -126,7 +126,7 @@
         <Message Text="Exporting Godot .pck to mods folder" Importance="high"/>
           <Exec Command="&quot;$(GodotPath)&quot; --headless --export-pack &quot;BasicExport&quot; &quot;$(Sts2Path)/mods/$(ModPackageName)/$(ModPackageName).pck&quot;"
               EnvironmentVariables="IsInnerGodotExport=true;MSBUILDDISABLENODEREUSE=1"
-              ContinueOnError="WarnAndContinue"/>
+              ContinueOnError="ErrorAndStop"/>
     </Target>
 
     <Target Name="PrepareGodotExportDependencies" BeforeTargets="GodotPublish" Condition="'$(GodotPath)' != '' and Exists('$(GodotPath)') and '$(IsInnerGodotExport)' != 'true'">
@@ -139,6 +139,14 @@
     </Target>
 
     <Target Name="GodotPublishSkipped" AfterTargets="Publish" Condition="'$(GodotPath)' == '' or !Exists('$(GodotPath)')">
-        <Message Text="Skipping Godot .pck export because GodotPath is not configured." Importance="high"/>
+        <Error Text="Godot .pck export is required but GodotPath is not configured or invalid. Create .env from .env.example and set GodotPath to Godot 4.5.1 Mono executable." />
+    </Target>
+
+    <Target Name="VerifyGodotPckOutput" AfterTargets="GodotPublish" Condition="'$(IsInnerGodotExport)' != 'true'">
+        <PropertyGroup>
+            <ExpectedPckPath>$(Sts2Path)/mods/$(ModPackageName)/$(ModPackageName).pck</ExpectedPckPath>
+        </PropertyGroup>
+        <Error Text="Godot export finished but pck file was not found: $(ExpectedPckPath)" Condition="!Exists('$(ExpectedPckPath)')" />
+        <Message Text="Godot .pck export verified: $(ExpectedPckPath)" Importance="high" Condition="Exists('$(ExpectedPckPath)')"/>
     </Target>
 </Project>

--- a/Patches/UpdateNoticePopupPatch.cs
+++ b/Patches/UpdateNoticePopupPatch.cs
@@ -1,0 +1,275 @@
+using Godot;
+using HarmonyLib;
+using MegaCrit.Sts2.Core.Nodes;
+using MegaCrit.Sts2.Core.Nodes.Screens.MainMenu;
+using ModTemplate.Config;
+
+namespace ModTemplate.Patches;
+
+[HarmonyPatch(typeof(NRun))]
+public static class UpdateNoticePopupPatch
+{
+  private static bool _hasShownInSession;
+
+  private static readonly string[] UpdateLines =
+  {
+    "1. 新增【更新通知】弹窗：进入游戏后会显示本版本更新内容。",
+    "2. 适配了游戏V0.99.1的更新。",
+    "3. 现在多次锻造buff下，可以看到查看升级效果按钮了。",
+    "4. 修复了部分mod添加的buff在无尽模式下不生效的问题。",
+    "5. 修复了部分mod添加的buff在无尽模式下不显示在modifier列表中的问题。",
+    "6. 添加了部分官方的buff到无尽模式的古代选择池中。",
+    "目前已知问题：",
+    "1. 到达第16幕后，打完boss后游戏可能会闪烁黑屏导致无法继续游戏，正在调查中。",
+    "2. 有玩家反馈在无尽模式中，拿完遗物会无法继续游戏，正在调查中，可以通过控制台输入‘travel’命令来继续游戏。",
+  };
+
+  [HarmonyPatch(nameof(NRun._Ready))]
+  [HarmonyPostfix]
+  private static void ShowUpdateNoticeAfterRunReady(NRun __instance)
+  {
+    TryShowUpdateNotice(__instance, "NRun._Ready");
+  }
+
+  [HarmonyPatch(nameof(NRun.SetCurrentRoom))]
+  [HarmonyPostfix]
+  private static void ShowUpdateNoticeAfterSetCurrentRoom(NRun __instance)
+  {
+    TryShowUpdateNotice(__instance, "NRun.SetCurrentRoom");
+  }
+
+  internal static void TryShowUpdateNotice(Node sourceNode, string trigger)
+  {
+    string version = MainFile.ModVersion;
+    string lastSeen = MoreCustomsConfig.Current.LastSeenUpdateNoticeVersion;
+    MainFile.Logger.Info($"[UpdateNotice] {trigger} triggered. currentVersion={version}, lastSeenVersion={lastSeen}, shownInSession={_hasShownInSession}");
+
+    if (_hasShownInSession)
+    {
+      MainFile.Logger.Info("[UpdateNotice] Skip show: already shown in current game session.");
+      return;
+    }
+
+    if (!MoreCustomsConfig.ShouldShowUpdateNotice(version))
+    {
+      MainFile.Logger.Info($"[UpdateNotice] Skip show: ShouldShowUpdateNotice returned false. currentVersion={version}, lastSeenVersion={lastSeen}");
+      return;
+    }
+
+    if (sourceNode.GetTree() == null)
+    {
+      MainFile.Logger.Warn("[UpdateNotice] Skip show: SceneTree is null.");
+      return;
+    }
+
+    if (sourceNode.GetTree().Root == null)
+    {
+      MainFile.Logger.Warn("[UpdateNotice] Skip show: SceneTree.Root is null.");
+      return;
+    }
+
+    if (sourceNode.GetTree().Root.GetNodeOrNull<CanvasLayer>("MoreCustomsUpdateNoticeLayer") != null)
+    {
+      MainFile.Logger.Info("[UpdateNotice] Skip show: popup layer already exists in scene tree.");
+      return;
+    }
+
+    _hasShownInSession = true;
+    CanvasLayer popupRoot = BuildPopup(version);
+    MainFile.Logger.Info($"[UpdateNotice] Popup node built. Name={popupRoot.Name}, Layer={popupRoot.Layer}, ChildCount={popupRoot.GetChildCount()}");
+    sourceNode.GetTree().Root.CallDeferred(Node.MethodName.AddChild, popupRoot);
+    MainFile.Logger.Info($"[UpdateNotice] AddChild deferred to SceneTree.Root. Showing update popup for version {version}.");
+  }
+
+  private static CanvasLayer BuildPopup(string version)
+  {
+    MainFile.Logger.Info($"[UpdateNotice] BuildPopup begin. version={version}");
+    CanvasLayer canvasLayer = new()
+    {
+      Name = "MoreCustomsUpdateNoticeLayer",
+      Layer = 200
+    };
+
+    Control overlay = new()
+    {
+      Name = "Overlay",
+      MouseFilter = Control.MouseFilterEnum.Stop
+    };
+    overlay.SetAnchorsPreset(Control.LayoutPreset.FullRect);
+    canvasLayer.AddChild(overlay);
+
+    ColorRect dimLayer = new()
+    {
+      Name = "DimLayer",
+      Color = new Color(0f, 0f, 0f, 0.72f),
+      MouseFilter = Control.MouseFilterEnum.Ignore
+    };
+    dimLayer.SetAnchorsPreset(Control.LayoutPreset.FullRect);
+    overlay.AddChild(dimLayer);
+
+    PanelContainer panelContainer = new()
+    {
+      Name = "UpdateNoticePanel",
+      CustomMinimumSize = new Vector2(880, 560),
+      SizeFlagsHorizontal = Control.SizeFlags.ShrinkCenter,
+      SizeFlagsVertical = Control.SizeFlags.ShrinkCenter,
+      MouseFilter = Control.MouseFilterEnum.Stop
+    };
+    panelContainer.SetAnchorsPreset(Control.LayoutPreset.Center);
+    panelContainer.AnchorLeft = 0.5f;
+    panelContainer.AnchorTop = 0.5f;
+    panelContainer.AnchorRight = 0.5f;
+    panelContainer.AnchorBottom = 0.5f;
+    panelContainer.OffsetLeft = -440;
+    panelContainer.OffsetTop = -280;
+    panelContainer.OffsetRight = 440;
+    panelContainer.OffsetBottom = 280;
+
+    StyleBoxFlat panelStyle = new()
+    {
+      BgColor = new Color(0.08f, 0.1f, 0.14f, 0.96f),
+      BorderColor = new Color(0.85f, 0.7f, 0.35f, 1f),
+      BorderWidthBottom = 2,
+      BorderWidthLeft = 2,
+      BorderWidthRight = 2,
+      BorderWidthTop = 2,
+      CornerRadiusBottomLeft = 14,
+      CornerRadiusBottomRight = 14,
+      CornerRadiusTopLeft = 14,
+      CornerRadiusTopRight = 14,
+      ShadowColor = new Color(0f, 0f, 0f, 0.35f),
+      ShadowSize = 8
+    };
+    panelContainer.AddThemeStyleboxOverride("panel", panelStyle);
+    overlay.AddChild(panelContainer);
+
+    MarginContainer marginContainer = new()
+    {
+      Name = "Margin"
+    };
+    marginContainer.AddThemeConstantOverride("margin_top", 20);
+    marginContainer.AddThemeConstantOverride("margin_bottom", 18);
+    marginContainer.AddThemeConstantOverride("margin_left", 24);
+    marginContainer.AddThemeConstantOverride("margin_right", 24);
+    panelContainer.AddChild(marginContainer);
+
+    VBoxContainer vBoxContainer = new()
+    {
+      Name = "Content"
+    };
+    vBoxContainer.AddThemeConstantOverride("separation", 14);
+    marginContainer.AddChild(vBoxContainer);
+
+    Label titleLabel = new()
+    {
+      Name = "Title",
+      Text = $"更多自定义 {version} 更新内容",
+      HorizontalAlignment = HorizontalAlignment.Center,
+      AutowrapMode = TextServer.AutowrapMode.WordSmart,
+      Modulate = new Color(1f, 0.93f, 0.75f, 1f)
+    };
+    titleLabel.AddThemeFontSizeOverride("font_size", 30);
+    vBoxContainer.AddChild(titleLabel);
+
+    Label subtitleLabel = new()
+    {
+      Name = "Subtitle",
+      Text = "感谢游玩 更多自定义，以下是本次版本的主要更新：",
+      HorizontalAlignment = HorizontalAlignment.Center,
+      AutowrapMode = TextServer.AutowrapMode.WordSmart,
+      Modulate = new Color(0.85f, 0.9f, 0.96f, 0.92f)
+    };
+    subtitleLabel.AddThemeFontSizeOverride("font_size", 16);
+    vBoxContainer.AddChild(subtitleLabel);
+
+    HSeparator separatorTop = new()
+    {
+      Name = "SeparatorTop"
+    };
+    vBoxContainer.AddChild(separatorTop);
+
+    RichTextLabel bodyLabel = new()
+    {
+      Name = "Body",
+      BbcodeEnabled = true,
+      FitContent = false,
+      ScrollActive = true,
+      SizeFlagsVertical = Control.SizeFlags.ExpandFill,
+      CustomMinimumSize = new Vector2(0, 320),
+      Text = BuildBodyText()
+    };
+    bodyLabel.AddThemeFontSizeOverride("normal_font_size", 18);
+    bodyLabel.Modulate = new Color(0.96f, 0.97f, 1f, 1f);
+    vBoxContainer.AddChild(bodyLabel);
+
+    HSeparator separatorBottom = new()
+    {
+      Name = "SeparatorBottom"
+    };
+    vBoxContainer.AddChild(separatorBottom);
+
+    HBoxContainer footer = new()
+    {
+      Name = "Footer"
+    };
+    footer.AddThemeConstantOverride("separation", 10);
+    vBoxContainer.AddChild(footer);
+
+    Label footerHint = new()
+    {
+      Name = "FooterHint",
+      Text = "提示：同一版本仅显示一次，更新版本后会再次出现。",
+      SizeFlagsHorizontal = Control.SizeFlags.ExpandFill,
+      VerticalAlignment = VerticalAlignment.Center,
+      Modulate = new Color(0.78f, 0.84f, 0.92f, 0.9f)
+    };
+    footerHint.AddThemeFontSizeOverride("font_size", 14);
+    footer.AddChild(footerHint);
+
+    Button okButton = new()
+    {
+      Name = "ConfirmButton",
+      Text = "知道了",
+      SizeFlagsHorizontal = Control.SizeFlags.ShrinkEnd,
+      CustomMinimumSize = new Vector2(160, 46)
+    };
+    okButton.AddThemeFontSizeOverride("font_size", 18);
+
+    okButton.Pressed += () =>
+    {
+      MoreCustomsConfig.MarkUpdateNoticeSeen(version);
+      canvasLayer.QueueFree();
+      MainFile.Logger.Info($"[UpdateNotice] Version {version} marked as seen.");
+    };
+
+    footer.AddChild(okButton);
+    MainFile.Logger.Info("[UpdateNotice] BuildPopup complete.");
+
+    return canvasLayer;
+  }
+
+  private static string BuildBodyText()
+  {
+    return string.Join("\n", UpdateLines);
+  }
+}
+
+[HarmonyPatch(typeof(NGame), nameof(NGame._Ready))]
+public static class UpdateNoticeGameReadyPatch
+{
+  [HarmonyPostfix]
+  private static void ShowUpdateNoticeAfterGameReady(NGame __instance)
+  {
+    UpdateNoticePopupPatch.TryShowUpdateNotice(__instance, "NGame._Ready(startup)");
+  }
+}
+
+[HarmonyPatch(typeof(NMainMenu), nameof(NMainMenu._Ready))]
+public static class UpdateNoticeMainMenuReadyPatch
+{
+  [HarmonyPostfix]
+  private static void ShowUpdateNoticeAfterMainMenuReady(NMainMenu __instance)
+  {
+    UpdateNoticePopupPatch.TryShowUpdateNotice(__instance, "NMainMenu._Ready(startup)");
+  }
+}


### PR DESCRIPTION
## 变更内容
- 新增启动阶段更新通知弹窗（NGame/NMainMenu 触发，NRun 兜底）
- 新增版本已读记录与日志诊断
- 美化更新通知窗口样式
- publish 强制校验 pck 导出

Closes #8